### PR TITLE
Fixes issue 361 Room Capacity Number Input Allows Negative Values

### DIFF
--- a/app/templates/buildingManagement.html
+++ b/app/templates/buildingManagement.html
@@ -68,7 +68,7 @@
                                     </div><br>
                                     <div aria-labelledby="Room Capacity">
                                         <strong>Room Capacity: </strong>
-                                        <input class="form-control" id="roomCapacity" type="number"></input>
+                                        <input class="form-control" id="roomCapacity" type="number" min="0"></input>
                                     </div><br>
                                     <div aria-labelledby="Room Type">
                                         <strong>Room Type: </strong>


### PR DESCRIPTION
Added min='0' in buildingManagement.html to fix the form-control allowing negative values to be inputted. 
To test, go to building management and type in a negative value or use the arrows to decrease the number. 