### PR TITLE
centered submit button

### DIFF
--- a/app/templates/snips/courseElements/createCourse.html
+++ b/app/templates/snips/courseElements/createCourse.html
@@ -61,13 +61,13 @@
                   	        selected
                 	      {% endif %}
                 	    >{{credit_value}}</option>
-              		  {% endfor %}		
-			  	
+              		  {% endfor %}
+
 			  {#<option value="0.25">0.25</option>
                            <option value="0.5">0.5</option>
                            <option selected value="1.0">1.0</option>
 			   <option value="1.5">1.5</option>#}
-                        </select>	
+                        </select>
                     </div>
 		    <div class="form-group col-md-4" style="display:none">
                         <label for="offCampusFlag">Off-campus: </label></br>
@@ -125,7 +125,7 @@
 
               </form>
               <div class="btn-toolbar pull-right">
-                <button form="createCourseForm" type="submit" name="formBtn" value="submit" class="btn btn-success " id="submitAdd" style="margin-top:25px; boder-color:black;">Submit</button>
+                <button form="createCourseForm" type="submit" name="formBtn" value="submit" class="btn btn-success " id="submitAdd" style="margin-top:-5px; margin-right:-15px; border-color:black;">Submit</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR fixes issue #359 
The submit button on the create course modal was off-center and a little to the left. I shifted the button to the right so it aligns with the text box and shifted it up so it wasn't overlapping the modal border. Corrected border-color misspelling.

To test: 
Head over to Courses on the navbar, select term, then select "schedule a course". This will pop up the modal where the button we fixed is located. 

Before: 
![image](https://user-images.githubusercontent.com/67805799/120507113-86dae280-c394-11eb-99ae-897ac570fe94.png)

After: 
![Screenshot (71)](https://user-images.githubusercontent.com/67805799/120507446-d1f4f580-c394-11eb-8ae4-87d6468adbe0.png)


