### PR TITLE
removed jinja conditional that checks for approved_special_topics

### DIFF
--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -179,7 +179,6 @@
       </tr>
   {% endfor %}
   {% for course in specialCourses %}
-      {% if course.course not in  approved_special_topics %}
           <tr>
               <!--COURSE NAME-->
               <td>
@@ -333,7 +332,6 @@
               {% endif %}
           {% endif %}
           </tr>
-      {% endif %}
   {% endfor %}
 
     </tbody>


### PR DESCRIPTION
This PR fixes issue #312 
The original issue was already fixed. It appears that they forgot to select an instructor when creating the class. 
When creating a new special topic course and adding a special topic name, the app broke when checking a jinja conditional that checked if the course was in `approved_special_topics`.
We removed the jinja conditional that checks for `approved_special_topics` in `app/templates/snips/courseElements/adminCourseTable.html`

We created multiple special topic courses and tested all the different cases (approved, incomplete, etc.)

To test: 
go to the courses page and add a special topics course.
go to course management under administration.
change the status of the submitted special topics course. 
go back to the courses page and find the updated special topics course.