### PR TITLE
CAS #358: Wording When Scheduling a Course

### DIFF
--- a/app/templates/course.html
+++ b/app/templates/course.html
@@ -18,9 +18,9 @@
                         {% include "snips/courseElements/adminCourseTable.html" %}
                     </table>
                     <br>
-                    {% if (can_edit == True and curTermName.term_state.order == 1) or current_user.isAdmin == True %}
+                    {% if (can_edit == True and curTermName.term_state.name == "schedule_opened") or current_user.isAdmin == True %}
                         {% include "snips/courseElements/createCourse.html" %}
-                    {% elif (can_edit == False and curTermName.term_state.order == 1) %}
+                    {% elif (can_edit == False and curTermName.term_state.name == "schedule_opened") %}
                         <p>User is not authorized to schedule in this division. Please contact the registrar office or the admin of this site.</p>
                     {% else %}
                         <br>

--- a/app/templates/course.html
+++ b/app/templates/course.html
@@ -20,6 +20,8 @@
                     <br>
                     {% if (can_edit == True and curTermName.term_state.order == 1) or current_user.isAdmin == True %}
                         {% include "snips/courseElements/createCourse.html" %}
+                    {% elif (can_edit == False and curTermName.term_state.order == 1) %}
+                        <p>User is not authorized to schedule in this division. Please contact the registrar office or the admin of this site.</p>
                     {% else %}
                         <br>
                         <p>Scheduling is closed for this term. Please contact the registrar office or the admin of this site.</p>


### PR DESCRIPTION
Problem: If the user tries to schedule a course to a division they do not have access to, the wording is weird.  The term is open, but if the user tries to schedule a class for a division that they do not have access to, it says that the term is closed. It should be a different message for when the term is closed or the user doesn’t have access to a course.
Solution: We added another else if statement in course.html that checks if can_edit is False and scheduling is open. It will not allow the user to edit the course, and it will print out the statement: “User is not authorized to schedule in this division. Please contact the registrar office or the admin of this site.”
Testing:
In the database: Make the user admin only. Result: User should be able to schedule a course in every division even if scheduling is open for that term.
Make the user a division chair only. Make term state id in Terms equal 2. Result: User should be able to edit a course in their own division only. If they try to edit the course in a division outside of theirs, the message will be shown: “User is not authorized to schedule in this division. Please contact the registrar office or the admin of this site.”
Make the user a program chair only. Make term state id equal to 2. Result: User should be able to edit a course in their program only. If they try to edit the course in a program outside of theirs, the message will be shown: “User is not authorized to schedule in this division. Please contact the registrar office or the admin of this site.”
Make the user a division chair only. Make term state id anything that is not equal to 2. Result: User should not be able to edit a course in any division. If they try to edit the course in their own division, the message will be shown: “Scheduling is closed for this term. Please contact the registrar office or the admin of this site.”
Make the user a program chair only. Make term state id that is not equal to 2. Result: User should not be able to edit a course in their program or any other program. If they try to edit the course in their program, the message will be shown: “Scheduling is closed for this term. Please contact the registrar office or the admin of this site.”
Remove any admin, program chair, and division chair privilege from the user and Make term state id equal to 2 . Result: User should not be able to add or edit courses in any division. The message shown: “User is not authorized to schedule in this division. Please contact the registrar office or the admin of this site.”