### PR TITLE
Added an option to credit load for edit special topics for admin

### DIFF
--- a/app/templates/snips/courseElements/editSTCourse.html
+++ b/app/templates/snips/courseElements/editSTCourse.html
@@ -133,6 +133,9 @@
                   <option value="1.5" {% if course.faculty_credit=="1.5" %}
                       selected
                     {% endif %}>1.5</option>
+                  <option value="2.0" {% if course.faculty_credit=="2.0" %}
+                      selected
+                    {% endif %}>2.0</option>
                 </select>
                 </div>
             </div>


### PR DESCRIPTION
This fixes issue #393 
 
Summary:
In the Course Management page, when editing (approving/denying) a special topics course, the faculty credit load select picker was not showing an option for 2.0 credits. This PR added the missing option to the select picker.

File changed: 
`app/templates/snips/courseElements/editSTCourse.html`

To test:
In the Courses page create a new special topics course.
In the Course management page under Administration, edit the special topics course and click on the faculty credit load select picker. 
There should be an option for 2.0 credits at the bottom of the list.

**NOTE**:  The Course Management main page might be broken due to an issue with crosslisted courses. Paste this url: `https://[your ip]/courseManagement/specialCourses/202112` to view the special topics courses in the Course Management page. If the crosslisted issue has not been fixed.