### PR TITLE
Cross listed course

### DIFF
--- a/app/controllers/admin_routes/courseManagement.py
+++ b/app/controllers/admin_routes/courseManagement.py
@@ -53,6 +53,7 @@ def crossListed(tid):
         # log.writer("Unable to parse Term ID, courseManagment.py", e)
         pass
     cfg = load_config()
+    
     return render_template("crossListed.html",
                            allTerms=terms,
                            page=page,

--- a/app/secret_config.yaml
+++ b/app/secret_config.yaml
@@ -12,13 +12,12 @@ databases:
   # prod: ""
 databaseAdmin:
   user: ['heggens','myersco']
-# Testing
-# Testing
+
 db:
   db_name: cas
   host: localhost
-  password: jarju1234! # FIXME: add your password
-  username: jarjug  # FIXME: add your username
+  password: password # FIXME: add your password
+  username: root     # FIXME: add your username
 
 # Correct for display, but does not match DB.
 scheduleDays:

--- a/app/secret_config.yaml
+++ b/app/secret_config.yaml
@@ -13,6 +13,7 @@ databases:
 databaseAdmin:
   user: ['heggens','myersco']
 # Testing
+# Testing
 db:
   db_name: cas
   host: localhost

--- a/app/secret_config.yaml
+++ b/app/secret_config.yaml
@@ -12,12 +12,12 @@ databases:
   # prod: ""
 databaseAdmin:
   user: ['heggens','myersco']
-
+# Testing
 db:
   db_name: cas
   host: localhost
-  password: password # FIXME: add your password
-  username: root     # FIXME: add your username
+  password: jarju1234! # FIXME: add your password
+  username: jarjug  # FIXME: add your username
 
 # Correct for display, but does not match DB.
 scheduleDays:

--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -92,6 +92,7 @@
             <td>
                 {% if course in crosslisted %}
                 <div class="form-check" id="checkcross">
+                  {% if can_edit == True %}
                     {% if crosslisted[course][0] %}
                     <input type="checkbox" name="cid" value="{{course.cId}}" onclick="verifyCrosslisted({{course.cId}});" id="coursestatus{{course.cId}}" checked>
                     <label data-toggle="tooltip" data-placement="right" title="Verifies the schedule added by another department" class="form-check-label" for="exampleCheck1">Verify <span class="glyphicon glyphicon-question-sign"></span></label>
@@ -99,6 +100,7 @@
                     <input type="checkbox" name="cid" value="{{course.cId}}" onclick="verifyCrosslisted({{course.cId}});" id="coursestatus{{course.cId}}">
                     <label data-toggle="tooltip" data-placement="right" title="Verifies the schedule added by another department" class="form-check-label" for="exampleCheck1">Verify <span class="glyphicon glyphicon-question-sign"></span></label>
                     {% endif %}
+                  {% endif %}
                 </div>
 		<div class="row">
                     {% for cross_course in crosslisted[course][1:] %}
@@ -111,8 +113,7 @@
                                   <span class="glyphicon glyphicon-ok" style="color:green; clear:both; " aria-hidden="true"></span> {{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }}
                             </span>
                         {% endif %}
-
-                    {% endfor %}
+                      {% endfor %}
 		</div>
                 {% else %}
                     No
@@ -254,6 +255,7 @@
               <td>
                   {% if course in crosslisted %}
                   <div class="form-check" id="checkcross">
+                    {% if can_edit == True %}
                       {% if crosslisted[course][0] %}
                       <input type="checkbox" name="cid" value="{{course.cId}}" onclick="verifyCrosslisted({{crosslisted[course][0].cId}});" id="coursestatus" checked>
                       <label data-toggle="tooltip" data-placement="right" title="Verifies the schedule added by another department" class="form-check-label" for="exampleCheck1">Verify <span class="glyphicon glyphicon-question-sign"></span></label>
@@ -261,6 +263,7 @@
                       <input type="checkbox" name="cid" value="{{course.cId}}" onclick="verifyCrosslisted({{crosslisted[course][0].cId}});" id="coursestatus">
                       <label data-toggle="tooltip" data-placement="right" title="Verifies the schedule added by another department" class="form-check-label" for="exampleCheck1">Verify <span class="glyphicon glyphicon-question-sign"></span></label>
                       {% endif %}
+                    {% endif %}
                   </div>
                       {% for cross_course in crosslisted[course][1:] %}
                           {% if cross_course.verified == False %}

--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -113,7 +113,7 @@
                                   <span class="glyphicon glyphicon-ok" style="color:green; clear:both; " aria-hidden="true"></span> {{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }}
                             </span>
                         {% endif %}
-                      {% endfor %}
+                    {% endfor %}
 		</div>
                 {% else %}
                     No


### PR DESCRIPTION
**Problem:** Only program chair, division chair,and admin should have the ability to check off the cross-listed verify checkbox.  However, everyone is able to check off the cross-listed verified checkbox despitenot having those admin privileges. 


**Solution:** We added an if-statement to check if can_edit is true (because only  program chair, division chair,and admin can have can_edit rights) before allowing them to check of or uncheck the verify cross-listed checkbox.



**Testing:** Assuming that you are logged in as Admin, schedule a course; this should allow you to check or uncheck the verify cross listed course checkbox. 

- In the database, remove admin privilege, remove division chair privilege and make user program chair of the course that was scheduled previously; run the web browser and you should be able to check off the cross-listed verify checkbox. 

- Remove admin privilege, remove program chair privilege and make user division chair of the course that was scheduled; run the web browser and you should be able to check off the cross-listed verify checkbox. 

- Remove all privileges (program chair, division chair,and admin); run the web browser and you should not be able to see the checkbox on the cross-listed column. 