### PR TITLE
Properly routing custom error pages.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,6 @@ from flask import Flask
 
 app = Flask(__name__)
 from app.allImports import *
-
 # def load_config(file):
 #     with open(file, 'r') as ymlfile:
 #         cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
@@ -32,8 +31,8 @@ from app.login_manager import *
 from app.controllers.main_routes import main_bp as main_bp
 app.register_blueprint(main_bp)
 
-from app.controllers.error_routes import error_bp as error_bp
-app.register_blueprint(error_bp)
+# from app.controllers.error_routes import error_bp as error_bp
+# app.register_blueprint(error_bp)
 
 from app.controllers.admin_routes import admin_bp as admin_bp
 app.register_blueprint(admin_bp)

--- a/app/allImports.py
+++ b/app/allImports.py
@@ -22,5 +22,5 @@ import pprint
 from flask_login import login_user, logout_user, current_user, LoginManager, login_required
 
 from app.loadConfig import load_config
-
 cfg = load_config()
+from app.controllers.error_routes import errorHandler

--- a/app/controllers/error_routes/errorHandler.py
+++ b/app/controllers/error_routes/errorHandler.py
@@ -4,10 +4,6 @@ from app import *
 
 from app.allImports import *
 
-@app.errorhandler(401)
-def unauthorized(e):
-    return render_template('/snips/errors/401.html', cfg = cfg), 401
-
 @app.errorhandler(403)
 def unauthenticated(e):
     return render_template('/snips/errors/403.html', cfg = cfg), 403

--- a/app/controllers/error_routes/errorHandler.py
+++ b/app/controllers/error_routes/errorHandler.py
@@ -1,16 +1,21 @@
 from app.controllers.error_routes import *
+from app import *
 # from app.controllers.admin_routes import *
 
 from app.allImports import *
 
-@error_bp.errorhandler(401)
+@app.errorhandler(401)
 def unauthorized(e):
-    return render_template('/snips/errors/401.html'), 401
+    return render_template('/snips/errors/401.html', cfg = cfg), 401
 
-@error_bp.errorhandler(403)
+@app.errorhandler(403)
 def unauthenticated(e):
-    return render_template('/snips/errors/403.html'), 403
+    return render_template('/snips/errors/403.html', cfg = cfg), 403
 
-@error_bp.errorhandler(404)
+@app.errorhandler(404)
 def pageNotFound(e):
-    return render_template('/snips/errors/404.html'), 404
+    return render_template('/snips/errors/404.html', cfg = cfg), 404
+
+@app.errorhandler(500)
+def internalError(e):
+    return render_template('/snips/errors/500.html', cfg = cfg), 500

--- a/app/templates/snips/errors/401.html
+++ b/app/templates/snips/errors/401.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-{% set currentPage = 'no' %}
-{% block body %}
-<h2>Error (401): Access Denied</h2>
-<p>You are not authorized to access this system. You will need to be added as a user.</p>
-<p>Please contact system support.</p>
-{% endblock %}

--- a/app/templates/snips/errors/403.html
+++ b/app/templates/snips/errors/403.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{#{% set currentPage = 'no' %}#}
+{% set currentPage = 'no' %}
 
 
 {% block body %}

--- a/app/templates/snips/errors/404.html
+++ b/app/templates/snips/errors/404.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 {% set currentPage = 'no' %}
+
+
 {% block body %}
-<p>Error (404): Page not found</p>
+<h2>Error (404): Page not found.</h2>
+<p>Page not found. Check spelling in URL.</p>
+<p><a href = "/">Go back to safety.</a></p>
 {% endblock %}

--- a/app/templates/snips/errors/500.html
+++ b/app/templates/snips/errors/500.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% set currentPage = 'no' %}
+
+
+{% block body %}
+<h2>Error (500): Internal Error</h2>
+<p>Something went wrong.</p>
+<p>Please contact system support.</p>
+<p><a href = "/">Go back to safety.</a></p>
+{% endblock %}


### PR DESCRIPTION
This PR fixes Issue #355 

Summary: 
The routes to custom error pages were using Blueprints. After doing some research we realized Blueprints can't handle error 404, so we decided to use import statements instead of blueprints and then routed the types of errors to their correct custom error page. We then added a custom error page for a 500 error. 

Files changed: 
_app/templates/snips/errors/500.html_
_app/templates/snips/errors/404.html
app/templates/snips/errors/403.html
app/controllers/error_routes/errorHandler.py
app/allImports.py
app/\_\_init\_\_.py_

To Test:

- Error 403: Take away admin privileges and then visit the following URL: `https://<YOURIP>:8080/courseManagement/specialCourses/202112`
This should load a custom 403 error page.
- Error 404: Visit any page and add `/potato` to the end of the URL.
This should load a custom 404 error page.
- Error 500: Make sure DEBUG mode is turned off. Go to the Course page, and take off one of the numbers in the URL for the term code.
This should load a custom 500 error page.

NOTE: The \_\_init\_\_.py file for error handlers creates the Blueprint for error routes. Since we used imports for error handling this file may not be necessary. We didn't know whether to delete the file entirely so we left it but didn't reference it anywhere. If you think we should get rid of it completely let us know and we'll update our PR with the file deleted. We also commented out registering the Blueprint in the \_\_init\_\_.py file for app.py.



