### PR TITLE
Added closing table tag and fixed line break

### DIFF
--- a/app/templates/courseTable.html
+++ b/app/templates/courseTable.html
@@ -19,7 +19,7 @@
     <tbody>
         {% for dict_item in courseName_to_term %}
             <tr title="{{dict_item[1]}}">
-                <th scope = "row" >{{dict_item[0]}} </th> 
+                <th scope = "row" >{{dict_item[0]}} </th>
                     {% for term in terms %}
                         {% if term.termCode in courseName_to_term[dict_item] %}
                             <td>
@@ -34,11 +34,11 @@
                     {% endfor %}
             </tr>
         {% endfor %}
-    
+
     </tbody>
 
-    </table
-    </br>
+    </table>
+    <br>
     <p><strong>* To be used for planning purposes only.</strong></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
Issue was that there was no closing table tag for the admin course table. I added one and fixed the line break as well. It had a slash instead of just <br>. 
Files affected: courseTable.html
To test: not really a noticeable difference. But you can look at the code to see the missing tag and malformed break. 