### PR TITLE
CAS Issue #362 Modal on top of the modal

### DIFF
--- a/app/templates/snips/editableEducationTech.html
+++ b/app/templates/snips/editableEducationTech.html
@@ -153,17 +153,20 @@
         </p>
 
         <div class="collapse" id="collapseExample">
-          <div  class="mx-auto" style="width: 550px; fontSize=large"; align="center">
+          <div  class="mx-auto" style="width: 550px;" align="center">
           <p class="text-danger">Are you sure that you want to close this window without saving?</p>
           </div>
-            <button type="button" class="btn btn-danger btn-sm"  data-dismiss="modal" data-target="#edTechModal">Close Without Saving</button>
+            <div  class="mx-auto" style="width: 550px;" align="center">
+                <button type="button" class="btn btn-danger btn-sm"  data-dismiss="modal" data-target="#edTechModal">Close Without Saving</button>
+            </div>
+
         </div>
       </div>
 
 
 
 
-        <div class = "col-sm-6" align = "right">
+        <div class = "col-sm-10" align = "right">
           <button type="button"  class="btn btn-primary" data-dismiss="modal" onclick='saveEdTechChanges()' aria-labelledby="Save button">Save</button>
           </div>
       </div>

--- a/app/templates/snips/editableEducationTech.html
+++ b/app/templates/snips/editableEducationTech.html
@@ -147,27 +147,15 @@
           <!-- <button type="button" class="btn btn-warning"
 		  data-toggle='modal' data-target='#save_warning'>Close</button> -->
         <p>
-              <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
-           Cancel
-          </button>
+              <button class="btn btn-primary" type="button" data-dismiss="modal" data-target="edTechModal" aria-expanded="false">
+                Cancel</button>
+
         </p>
-
-        <div class="collapse" id="collapseExample">
-          <div  class="mx-auto" style="width: 550px;" align="center">
-          <p class="text-danger">Are you sure that you want to close this window without saving?</p>
-          </div>
-            <div  class="mx-auto" style="width: 550px;" align="center">
-                <button type="button" class="btn btn-danger btn-sm"  data-dismiss="modal" data-target="#edTechModal">Close Without Saving</button>
-            </div>
-
-        </div>
       </div>
 
-
-
-
         <div class = "col-sm-10" align = "right">
-          <button type="button"  class="btn btn-primary" data-dismiss="modal" onclick='saveEdTechChanges()' aria-labelledby="Save button">Save</button>
+          <button type="button"  class="btn btn-primary" data-dismiss="modal" onclick='saveEdTechChanges()' aria-labelledby="Save button">
+            Save</button>
           </div>
       </div>
       </div>

--- a/app/templates/snips/editableEducationTech.html
+++ b/app/templates/snips/editableEducationTech.html
@@ -144,8 +144,10 @@
       <div class="row">
         <div class = "col-sm-2" align = "left">
           <button type="button" class="btn btn-warning"
-		  data-toggle='modal' data-target='#save_warning'>Close</button>
+		  data-toggle='modal'>Close</button>
         </div>
+
+
         <div class = "col-sm-10" align = "right">
           <button type="button"  class="btn btn-primary" data-dismiss="modal" onclick='saveEdTechChanges()' aria-labelledby="Save button">Save</button>
           </div>

--- a/app/templates/snips/editableEducationTech.html
+++ b/app/templates/snips/editableEducationTech.html
@@ -1,3 +1,4 @@
+<!-- We'll continue -->
 {% include 'snips/saveWarning.html' %}
 <div class="modal fade" id="edTechModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">
@@ -11,10 +12,10 @@
         <table class="table table-striped">
             <tbody>
             {# {% for items in educationTech %} #}
-            <!--LOOP FOR GOING THROUGH STUFF IN THE ROOM SELECTED WITH RESPECT TO EDUCATION TECH-->  
+            <!--LOOP FOR GOING THROUGH STUFF IN THE ROOM SELECTED WITH RESPECT TO EDUCATION TECH-->
                     <tr>
                         <td>
-                          Chalkboard(s): 
+                          Chalkboard(s):
                         </td>
                         <td aria-labelledby="Chalkboards">
                           <span  style="float:left;"> <input type="number" class="form-control" id="chalkboards" /></span>
@@ -30,7 +31,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Projectors">
-                          Projector(s): 
+                          Projector(s):
                         </td>
                         <td>
                           <span  style="float:left;"><input type="number" class="form-control" min="0" id="projectors"/></span>
@@ -54,7 +55,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="student_workspace">
-                          Students Workstation(s): 
+                          Students Workstation(s):
                         </td>
                         <td>
                           <span  style="float:left;"><input type="number" class="form-control" min="0" id="student_workspace"/></span>
@@ -62,7 +63,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Whiteboards">
-                          Whiteboards: 
+                          Whiteboards:
                         </td>
                         <td>
                           <span  style="float:left;"><input type="number" class="form-control"  min="0" id="whiteboards"/></span>
@@ -70,16 +71,16 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Audio">
-                          Audio: 
+                          Audio:
                         </td>
                         <td>
                             <span  style="float:left;" class="checkbox-inline"><input id="audio" type="checkbox"/></span>
-                      
+
                         </td>
                     </tr>
                      <tr>
                         <td aria-labelledby="Blu_Ray">
-                          Blu-Ray: 
+                          Blu-Ray:
                          </td>
                         <td>
                           <span  style="float:left;" class="checkbox-inline"><input id="blu_ray" type="checkbox" /></span>
@@ -87,7 +88,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Doc_Cam">
-                            Doc Cam: 
+                            Doc Cam:
                         </td>
                         <td>
                           <span  style="float:left;" class="checkbox-inline"><input id="doc_cam" type="checkbox" /></span>
@@ -95,7 +96,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="DVD">
-                          DVD: 
+                          DVD:
                         </td>
                         <td>
                           <span  style="float:left;" class="checkbox-inline"><input id="dvd" type="checkbox" /></span>
@@ -103,7 +104,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Extro">
-                          Extro: 
+                          Extro:
                         </td>
                         <td>
                           <span  style="float:left;" class="checkbox-inline"><input id="extro" type="checkbox" /></span>
@@ -111,7 +112,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Mondopad">
-                          Mondopad: 
+                          Mondopad:
                         </td>
                         <td>
                             <span  style="float:left;" class="checkbox-inline"><input id="mondopad" type="checkbox" /></span>
@@ -119,7 +120,7 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="Technology Cart">
-                            Technology Cart: 
+                            Technology Cart:
                         </td>
                         <td>
                             <span  style="float:left;" class="checkbox-inline"><input id="tech_chart" type="checkbox"/></span>
@@ -127,22 +128,22 @@
                     </tr>
                     <tr>
                         <td aria-labelledby="VHS">
-                          VHS: 
+                          VHS:
                         </td>
                         <td>
                           <span  style="float:left;" class="checkbox-inline"><input id="vhs" type="checkbox" /></span>
-                          
+
                         </td>
                     </tr>
             {# {% endfor %} #}
             </tbody>
-        </table> 
+        </table>
        </div>
       </div>
       <div class="modal-footer" padding: "10px" style="margin-right:.4em;">
       <div class="row">
         <div class = "col-sm-2" align = "left">
-          <button type="button" class="btn btn-warning" 
+          <button type="button" class="btn btn-warning"
 		  data-toggle='modal' data-target='#save_warning'>Close</button>
         </div>
         <div class = "col-sm-10" align = "right">
@@ -153,5 +154,3 @@
     </div>
   </div>
 </div>
-                                                        
-                                                        

--- a/app/templates/snips/editableEducationTech.html
+++ b/app/templates/snips/editableEducationTech.html
@@ -140,15 +140,30 @@
         </table>
        </div>
       </div>
+
       <div class="modal-footer" padding: "10px" style="margin-right:.4em;">
       <div class="row">
         <div class = "col-sm-2" align = "left">
-          <button type="button" class="btn btn-warning"
-		  data-toggle='modal'>Close</button>
+          <!-- <button type="button" class="btn btn-warning"
+		  data-toggle='modal' data-target='#save_warning'>Close</button> -->
+        <p>
+              <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+           Cancel
+          </button>
+        </p>
+
+        <div class="collapse" id="collapseExample">
+          <div  class="mx-auto" style="width: 550px; fontSize=large"; align="center">
+          <p class="text-danger">Are you sure that you want to close this window without saving?</p>
+          </div>
+            <button type="button" class="btn btn-danger btn-sm"  data-dismiss="modal" data-target="#edTechModal">Close Without Saving</button>
         </div>
+      </div>
 
 
-        <div class = "col-sm-10" align = "right">
+
+
+        <div class = "col-sm-6" align = "right">
           <button type="button"  class="btn btn-primary" data-dismiss="modal" onclick='saveEdTechChanges()' aria-labelledby="Save button">Save</button>
           </div>
       </div>

--- a/app/templates/snips/editableEducationTech.html
+++ b/app/templates/snips/editableEducationTech.html
@@ -1,4 +1,3 @@
-<!-- We'll continue -->
 {% include 'snips/saveWarning.html' %}
 <div class="modal fade" id="edTechModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered" role="document">


### PR DESCRIPTION
**Problem:** In the Building Management > Edit > Education Tech Modal, when the cancel button is clicked, the warning modal pops up on top of the existing modal. 

**Solution:** We got rid of the warning modal. We renamed the button from close to cancel. When the cancel button is clicked, the modal closes without any warning, and changes will be discarded.

**Testing:** 

- In the Building Management > Edit > Education Tech Modal, make a change by either by checking/unchecking one or more boxes or changing a number. Click cancel and changes should be discarded and the modal closes. Open the modal again and check if the changes have not been saved. Refresh the page and open the modal again. The changes should not be saved.

-  In the Building Management > Edit > Education Tech Modal, make a change by either by checking/unchecking one or more boxes or changing a number. Click the save button; changes should be saved and the modal closes. Open the modal again and check if the changes have been saved. Refresh the page and open the modal again. The changes should be saved.