### PR TITLE
CAS Issue #400 Accessibility dropdown previewer

### DIFF
--- a/app/static/css/buildingManagement.css
+++ b/app/static/css/buildingManagement.css
@@ -19,7 +19,7 @@
 
 /* Tooltip text */
 .accessibilities .tooltip {
-  z-index: 2;
+  z-index: 9999;
 }
 
 .accessibilities .glyphicon {


### PR DESCRIPTION
**Problem:** In /buildingManagement, when a user uploads an image(s) to the dropzone box, the display of help text for the Accessibility dropdowns is always blocked by the image(s).

**Solution:** We brought the help-text box forward so that it is on top of the uploaded images by changing the z-index of .accessibilities .tooltip in the CSS file to a bigger number.

**Testing:** In /buildingManagement upload images to the dropzone. Hover over the accessibility help glyphicon. The help text box should be covering the images. 