### PR TITLE
Fixed error for overlapping modals and added 'x' icon to popover, then made popover on editActiveCourses into a tooltip.

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -29,3 +29,12 @@ footer{
         border-left: 1px solid #e7e7e7;
     }
 }
+
+a.close,
+a.close:hover,
+a.close:link {
+  color: #000000;
+  text-decoration: none;
+  padding-left: 5px;
+  margin-top: -3;
+}

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -32,9 +32,21 @@ footer{
 
 a.close,
 a.close:hover,
-a.close:link {
+a.close:link {                       /* Styling for popover */
   color: #000000;
   text-decoration: none;
   padding-left: 5px;
   margin-top: -3;
+}
+
+.tooltip-inner {                                      /* Styling for tooltip */
+  color: #000000;
+  background-color: #fff;
+  border-bottom-color: #fff;
+  border: 2px solid #000000;
+  filter: drop-shadow(rgba(0, 0, 0, 0.3) 0 2px 10px);
+}
+
+.tooltip.in {
+    opacity: 1;
 }

--- a/app/static/js/local/popup.js
+++ b/app/static/js/local/popup.js
@@ -1,6 +1,6 @@
 // on click make a pop-out for the notes
 $(document).ready(function(){
-    $('[data-toggle="popover"]').popover({
+    $('[data-toggle="popover"]').popover({               /* This creates and controls popover for course notes. */
         placement : 'top',
         html : true,
         trigger : 'focus',
@@ -11,7 +11,7 @@ $(document).ready(function(){
         $('[data-toggle="popover"]').parents(".popover").popover('hide');
     });
 
-    $('[data-toggle="tooltip"]').tooltip({
+    $('[data-toggle="tooltip"]').tooltip({              /* This creates and controls a tooltip for editActiveCourses */
       placement : 'top'
     })
 });

--- a/app/static/js/local/popup.js
+++ b/app/static/js/local/popup.js
@@ -1,7 +1,12 @@
 // on click make a pop-out for the notes
 $(document).ready(function(){
     $('[data-toggle="popover"]').popover({
-        placement : 'top',
-        trigger : 'focus',
-    });
+        placement : 'bottom',
+        animation : false,
+        html : true
+      });
+        
+      $(document).on("click", ".popover .close" , function(){
+          $(this).parents(".popover").popover('hide');
+      });
 });

--- a/app/static/js/local/popup.js
+++ b/app/static/js/local/popup.js
@@ -1,12 +1,17 @@
 // on click make a pop-out for the notes
 $(document).ready(function(){
     $('[data-toggle="popover"]').popover({
-        placement : 'bottom',
-        animation : false,
-        html : true
+        placement : 'top',
+        html : true,
+        trigger : 'focus',
+        title : 'Course Notes <a href="#" class="close" data-dismiss="alert">&times;</a>'
       });
-        
-      $(document).on("click", ".popover .close" , function(){
-          $(this).parents(".popover").popover('hide');
-      });
+
+    $(document).on("click", ".popover .close" , function(){
+        $('[data-toggle="popover"]').parents(".popover").popover('hide');
+    });
+
+    $('[data-toggle="tooltip"]').tooltip({
+      placement : 'top'
+    })
 });

--- a/app/static/js/local/popup.js
+++ b/app/static/js/local/popup.js
@@ -1,6 +1,7 @@
-// on click make a pop-out for the notes 
+// on click make a pop-out for the notes
 $(document).ready(function(){
     $('[data-toggle="popover"]').popover({
-        placement : 'top'
+        placement : 'top',
+        trigger : 'focus',
     });
 });

--- a/app/templates/conflicts.html
+++ b/app/templates/conflicts.html
@@ -74,10 +74,7 @@
                 <!--NOTES-->
                 <td>
                   {% if course.notes is not none %}
-                    <a href='javascript:;'
-                       data-toggle='popover'
-                       title='Course Notes'
-                       data-content='{% if course.notes is not none %}{{ course.notes }}{% endif %}'>Notes</a>
+                    <a href='javascript:;' data-toggle='popover' data-content='{{ course.notes }}'>Notes</a>
                   {% else %}
                     <p>Notes</p>
                   {% endif %}

--- a/app/templates/editActiveCourses.html
+++ b/app/templates/editActiveCourses.html
@@ -18,7 +18,7 @@
     <div class="panel panel-default col-md-6">
       <div class="panel-heading">
         <h3 class="panel-title">Activate a Course
-          <a data-toggle="popover" data-content="Activating a course makes a course available for selection during the scheduling process.">
+          <a data-toggle="tooltip" title="Activating a course makes a course available for selection during the scheduling process.">
             <span class="glyphicon glyphicon-question-sign"></span>
           </a>
         </h3>
@@ -44,7 +44,7 @@
       <div class="panel panel-default col-md-6" style="margin-top: 50px; clear: both;">
         <div class="panel-heading">
           <h3 class="panel-title">Deactivate a Course
-            <a data-toggle="popover" data-content="Deactivating a course makes a course unavailable for selection during the scheduling process.">
+            <a data-toggle="tooltip" title="Deactivating a course makes a course unavailable for selection during the scheduling process.">
               <span class="glyphicon glyphicon-question-sign"></span>
             </a>
           </h3>

--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -122,7 +122,7 @@
             <!--NOTES-->
             <td>
                 {% if course.notes is not none %}
-                    <a href='javascript:;'  data-toggle='popover' title='Course Notes' data-content='{{ course.notes }}'>Notes</a>
+                    <a href='javascript:;'  tabindex='0' data-toggle='popover' data-trigger='focus' title='Course Notes' data-content='{{ course.notes }}'>Notes</a>
                 {% else %}
                     <p>Notes</p>
                 {% endif %}

--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="/static/css/table.css" type="text/css" />
+<script src="/static/js/local/popup.js"></script>
 {#This is the HTML for the courses table! aka /courses/term/program Yeah I know it says Admin in the title but its for both -Kay 11/11/19 #}
 {% include "snips/courseElements/deleteSTCourse.html" %}
 <thead>
@@ -122,7 +123,7 @@
             <!--NOTES-->
             <td>
                 {% if course.notes is not none %}
-                    <a href='javascript:;'  html=true data-templatefile="popup.js" data-toggle='popover' title='Course Notes <a href="#" class="close" data-dismiss="alert">&times;</a>' data-content='{{ course.notes }}'>Notes <script src="/static/js/local/popup.js"></script></a>
+                    <a href='javascript:;' data-toggle='popover' data-content='{{ course.notes }}'>Notes </a>
                     <!-- <a href='javascript:;'  tabindex='0' data-toggle='popover' html = true data-trigger='focus' title='Course Notes' data-content='{{ course.notes }}'>Notes</a> -->
                 {% else %}
                     <p>Notes</p>
@@ -284,7 +285,7 @@
           <!--NOTES-->
           <td>
               {% if course.notes is not none %}
-                  <a href='javascript:;'  data-toggle='popover' title='Course Notes' data-content='{{ course.notes }}'>Notes</a>
+              <a href='javascript:;' data-toggle='popover' data-content='{{ course.notes }}'>Notes</a>
               {% else %}
                   <p>Notes</p>
               {% endif %}

--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -122,7 +122,8 @@
             <!--NOTES-->
             <td>
                 {% if course.notes is not none %}
-                    <a href='javascript:;'  tabindex='0' data-toggle='popover' data-trigger='focus' title='Course Notes' data-content='{{ course.notes }}'>Notes</a>
+                    <a href='javascript:;'  html=true data-templatefile="popup.js" data-toggle='popover' title='Course Notes <a href="#" class="close" data-dismiss="alert">&times;</a>' data-content='{{ course.notes }}'>Notes <script src="/static/js/local/popup.js"></script></a>
+                    <!-- <a href='javascript:;'  tabindex='0' data-toggle='popover' html = true data-trigger='focus' title='Course Notes' data-content='{{ course.notes }}'>Notes</a> -->
                 {% else %}
                     <p>Notes</p>
                 {% endif %}

--- a/app/templates/snips/courseElements/adminSpecialTopicsTable.html
+++ b/app/templates/snips/courseElements/adminSpecialTopicsTable.html
@@ -102,7 +102,7 @@
                 <!--NOTES-->
                 <td>
                     {% if course.notes is not none %}
-                        <a href='javascript:;'  data-toggle='popover' title='Course Notes' data-content='{{ course.notes }}'>Notes</a>
+                    <a href='javascript:;' data-toggle='popover' data-content='{{ course.notes }}'>Notes</a>
                     {% else %}
                         <p>Notes</p>
                     {% endif %}

--- a/app/templates/special_time.html
+++ b/app/templates/special_time.html
@@ -17,38 +17,38 @@
               <tr>
                 <!--COURSE NAME-->
                 <td>
-                  {{course.prefix.prefix}} 
-                  {{course.bannerRef.number}} 
-                  {% if course.specialTopicName is not none %} 
-                    {{course.specialTopicName}} 
-                  {% else %} 
-                    {{course.bannerRef.ctitle}} 
+                  {{course.prefix.prefix}}
+                  {{course.bannerRef.number}}
+                  {% if course.specialTopicName is not none %}
+                    {{course.specialTopicName}}
+                  {% else %}
+                    {{course.bannerRef.ctitle}}
                   {%endif%}
                 </td>
                 <!--TAUGHT BY-->
                 <!--Needed in one line so names wrap correctly-->
                 <td>
-                  {% for instructorcourse in course.instructors_course_prefetch %} 
+                  {% for instructorcourse in course.instructors_course_prefetch %}
                     {{instructorcourse.username.firstName[0]+".  "+instructorcourse.username.lastName}}
                   {% endfor %}
                 </td>
                 <!--SCHEDULE-->
                 <td>
-                  {% if course.schedule is not none %} 
-                    {% for day in course.schedule.days %} {{ day.day }} 
-                  {% endfor %} 
-                    {{course.schedule.startTime.strftime('%I:%M%p')}}-{{course.schedule.endTime.strftime('%I:%M%p')}} 
+                  {% if course.schedule is not none %}
+                    {% for day in course.schedule.days %} {{ day.day }}
+                  {% endfor %}
+                    {{course.schedule.startTime.strftime('%I:%M%p')}}-{{course.schedule.endTime.strftime('%I:%M%p')}}
                   {% endif %}
                 </td>
                 <!--CAPACITY-->
                 <td>
-                  {% if course.capacity is not none %} 
-                    {{course.capacity}} 
+                  {% if course.capacity is not none %}
+                    {{course.capacity}}
                   {% endif %}
                 </td>
                 <!-- ROOM -->
                 <td>
-                  {% if course.rid is not none %} 
+                  {% if course.rid is not none %}
                     {{course.rid.building.name}}:{{course.rid.number}}
                   {% else %}
                     <p>No room listed</p>
@@ -65,10 +65,7 @@
                 <!--NOTES-->
                 <td>
                   {% if course.notes is not none %}
-                    <a href='javascript:;' 
-                       data-toggle='popover' 
-                       title='Course Notes' 
-                       data-content='{% if course.notes is not none %}{{ course.notes }}{% endif %}'>Notes</a> 
+                    <a href='javascript:;' data-toggle='popover' data-content='{{ course.notes }}'>Notes</a> 
                   {% else %}
                     <p>Notes</p>
                   {% endif %}

--- a/app/templates/tracker.html
+++ b/app/templates/tracker.html
@@ -92,9 +92,9 @@
                       {% if special != [] %}
                         <p>See Notes</p>
                       {% else %}
-                        {% for day in course.schedule.days %} 
-                          {{ day.day }} 
-                        {% endfor %} 
+                        {% for day in course.schedule.days %}
+                          {{ day.day }}
+                        {% endfor %}
                         {{course.schedule.startTime.strftime('%I:%M%p')}}-{{course.schedule.endTime.strftime('%I:%M%p')}}
                       {% endif %}
                     {% endif %}
@@ -118,9 +118,7 @@
                   </td>
                   <td id="notes"class="{{classDict[course.cId][7]}}">
                     {% if course.notes is not none %}
-                      <a href='javascript:;'  data-toggle='popover' title='Course Notes' data-content='{{ course.notes }}'>
-                        Notes
-                      </a>
+                      <a href='javascript:;' data-toggle='popover' data-content='{{ course.notes }}'>Notes</a>
                     {% else %}
                       <p>Notes</p>
                     {% endif %}


### PR DESCRIPTION
This PR fixes issue #281.

Summary: 
There was an issue occurring on the Course page under Notes causing the Note modals to overlap each other when more than one is opened. We implemented a `trigger: "Focus"` command that would cause a modal to close if the user clicks anywhere on the screen. We also included an 'X' icon to the popover title to make the popover more user-friendly. The `trigger: "Focus"` command caused another popover on the Edit Active Courses page under Course Management to break. To fix this we changed the popover into a tooltip. This fixed our error and seemed like a better implementation than the original popover. We then edited the `custom.css` file to style the new tooltips and the original popovers to better match the user interface.  We included comments on our changes to indicate their purpose. To make our changes on the `popup.js` file reflect the Course page we had to add a script that imported the `popup.js` file into `adminCourseTable.html`. In the `conflicts.html` file, we corrected a redundant conditional and changed the `a` tag to fit the `a` tag in the `adminCourseTable.html` file. We also corrected the `a` tags in the `adminSpecialTopicsTable.html` and `tracker.html` files.

To Test:
Popover: 
Go to the Courses tab and find a clickable Notes label under the Notes column. When clicked you will see our changes to the popover, if you then click anywhere on the screen you will see the popover closes itself. You can also visit any of the pages corresponding to the HTML files we changed and view the same functionality.
Tooltip:
Go to the Course Management tab and click on the Edit Active Courses tab on the left sidebar. On the new page, you will see two question mark icons, hovering over either one will display the tooltip. 

NOTES: When visiting the Course Management page there is a known error regarding cross-listed courses. This error may cause the page to break if at the time of testing the error has not been fixed. If this occurs paste this: `https://<YOURIP>:8080/courseManagement/specialCourses/202112` into the URL and this should bypass the error.