### PR TITLE
footer does not overlay over buttons

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -1,13 +1,13 @@
 body {
     background-color: #f8f8f8;
-
+    padding-bottom: 40px;
 }
 footer{
     background-color:#2c3e50;
     color:#fff;
 }
 .footer{
-    padding-top:1vh;
+    padding-top:0.7vh;
     background-color: inherit;
 }
 


### PR DESCRIPTION
Issue was that the footer was overlapping with buttons in term management and the courses page. Added padding-bottom to the body for space and reduced the height of the footer by 0.3vh. 
To test:
Navigate through term management and the courses page. There should be no major overlapping of content. 