### PR TITLE
Ordering Course Name Alphabetically

### DIFF
--- a/app/controllers/main_routes/selectProgram.py
+++ b/app/controllers/main_routes/selectProgram.py
@@ -14,7 +14,7 @@ from app.models.models import Program, Subject
 #FIXME: @require_authorization
 def selectProgram():
     cfg = load_config()
-    programs = Program.select()
+    programs = Program.select().order_by(Program.name)
     subjects = Subject.select()
     return render_template("selectProgram.html",
                             allPrograms=programs,

--- a/app/templates/snips/sidebars/coursesSidebar.html
+++ b/app/templates/snips/sidebars/coursesSidebar.html
@@ -30,7 +30,7 @@
 
                         <li>
                             <a class="first-level" href="#">{{division.name}}<span class="arrow pull-right glyphicon glyphicon-chevron-down"></span></a>
-                            {% for program in division.programs %}
+                            {% for program in division.programs | sort(attribute="name") %}
                             <ul class="nav nav-second-level">
                                 <li>
                                     <a href="#">{{program.name}}</a>


### PR DESCRIPTION
Issue: TAD recently changes to ETAD, so the order of courses in the database is no longer in alphabetical order. The Programs in `/selectProgram` are not displayed alphabetically. 

Fix: 
- Sorted those lists alphabetically

Test: 
- On the home page, click on Course > select A Term. This leads to course/tId/program. On that page's sidebar, click on Division II. The ETAD should appear above Sustainability. All Courses in the Division are now ordered alphabetically.
- Navigate to /selectProgram. Click on the dropdown. The program names should be in alphabetical order.
