### PR TITLE
CAS: Crosslisted Functionality Broken 

### DIFF
--- a/app/controllers/admin_routes/courseManagement.py
+++ b/app/controllers/admin_routes/courseManagement.py
@@ -53,13 +53,24 @@ def crossListed(tid):
         # log.writer("Unable to parse Term ID, courseManagment.py", e)
         pass
     cfg = load_config()
-    
+    # for course in courses_prefetch:
+    #     print("course",course,"type:",type(course))
+
+    crossCourses = CrossListed.select().where(CrossListed.term == tid)
+    crosslisted_table = {}
+    for course in list(crossCourses):
+        if course not in crosslisted_table:
+            crosslisted_table[course.courseId] = []
+        crosslisted_table[course.courseId].append(course.verified)
+        crosslisted_table[course.courseId].append(course)
+        
+
     return render_template("crossListed.html",
                            allTerms=terms,
                            page=page,
                            currentTerm=int(tid),
                            courses=courses_prefetch,
-                           crosslisted=[],
+                           crosslisted= crosslisted_table,
                            #courseInfo=courseInfo,
                            schedules=schedules,
                            rooms=rooms,
@@ -67,7 +78,6 @@ def crossListed(tid):
                            cfg = cfg,
                            curTermName = curTermName,
                            isAdmin = au.user.isAdmin
-
                            )
 #############################
 #SCHEDULE AND ROOM CONFLICTS#

--- a/app/templates/snips/courseElements/adminCourseTable.html
+++ b/app/templates/snips/courseElements/adminCourseTable.html
@@ -92,6 +92,7 @@
             <!--CROSS LISTED-->
             <td>
                 {% if course in crosslisted %}
+
                 <div class="form-check" id="checkcross">
                   {% if can_edit == True %}
                     {% if crosslisted[course][0] %}
@@ -103,24 +104,24 @@
                     {% endif %}
                   {% endif %}
                 </div>
-		<div class="row">
+		           <div class="row">
                     {% for cross_course in crosslisted[course][1:] %}
                         {% if cross_course.verified == False %}
                             <span data-toggle="tooltip" title="{{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }} has not been verified yet." style="margin-bottom:2px; margin-right:2px; white-space:nowrap; line-height:2.3;" class="btn-default btn-sm">
                                   <span class="glyphicon glyphicon-remove" style="color:red; clear:both;" aria-hidden="true"></span> {{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }}
                             </span>
-                        {% else %}
-                            <span data-toggle="tooltip" title="{{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }} has been verified." style="margin-bottom:2px; margin-right:2px; white-space:nowrap; line-height:2.3;" class="btn-default btn-sm">
-                                  <span class="glyphicon glyphicon-ok" style="color:green; clear:both; " aria-hidden="true"></span> {{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }}
-                            </span>
+                            {% else %}
+                                <span data-toggle="tooltip" title="{{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }} has been verified." style="margin-bottom:2px; margin-right:2px; white-space:nowrap; line-height:2.3;" class="btn-default btn-sm">
+                                      <span class="glyphicon glyphicon-ok" style="color:green; clear:both; " aria-hidden="true"></span> {{cross_course.crosslistedCourse.prefix}}{{cross_course.crosslistedCourse.bannerRef.number }}
+                                </span>
                         {% endif %}
                     {% endfor %}
-		</div>
+		           </div>
                 {% else %}
+
                     No
                 {% endif %}
             </td>
-
             <!--NOTES-->
             <td>
                 {% if course.notes is not none %}


### PR DESCRIPTION
This PR solves issue #419 

**Description:**
There was no crosslisted parameter being passed to the template for the admin courseManagement page. This was resulting in an error since the variable did not exist. Intitialy, @bryantal  added an empty list as the parameter so that the page does not break. After analyzing critically the frontend page (app/templates/snips/courseElements/adminCourseTable.html) we thought that a dictionary datatype was the best structure to pass our data hence crosslisted is not a list in this PR. It is a dictionary. 

**Test.**
Navigate to courseManagement/crossListed. Change terms and confirm if the crosslisted column in the table is correct. 
![Screen Shot 2022-02-07 at 11 12 48 AM](https://user-images.githubusercontent.com/46546491/152826906-ecaef1f5-d323-43ba-9135-748551c339a6.png)

